### PR TITLE
Bug: Request path being used as transaction name

### DIFF
--- a/src/Middleware/NewRelicTransactionNameMiddleware.php
+++ b/src/Middleware/NewRelicTransactionNameMiddleware.php
@@ -20,23 +20,19 @@ class NewRelicTransactionNameMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Process an incoming server request and return a response, optionally delegating
-     * response creation to a handler.
-     *
-     * @param ServerRequestInterface  $request
-     * @param RequestHandlerInterface $handler
-     *
-     * @return ResponseInterface
-     * @throws \Throwable
+     * @inheritDoc
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $this->newRelicAgent->nameTransaction($this->getTransactionName($request));
+        $transactionName = $this->getTransactionName($request);
+        if ($transactionName !== null) {
+            $this->newRelicAgent->nameTransaction($transactionName);
+        }
 
         return $handler->handle($request);
     }
 
-    private function getTransactionName(ServerRequestInterface $request): string
+    private function getTransactionName(ServerRequestInterface $request): ?string
     {
         $routeResult = $request->getAttribute(RouteResult::class);
         if ($routeResult instanceof RouteResult) {
@@ -46,6 +42,6 @@ class NewRelicTransactionNameMiddleware implements MiddlewareInterface
             }
         }
 
-        return $request->getUri()->getPath();
+        return null;
     }
 }

--- a/src/Test/TestNewRelicAgent.php
+++ b/src/Test/TestNewRelicAgent.php
@@ -11,8 +11,8 @@ final class TestNewRelicAgent implements NewRelicAgentInterface
 {
     /** @var mixed[] */
     private $customParameters = [];
-    /** @var string */
-    private $transactionName = '';
+    /** @var string|null */
+    private $transactionName;
 
     /**
      * {@inheritdoc}
@@ -72,7 +72,7 @@ final class TestNewRelicAgent implements NewRelicAgentInterface
         return $this->customParameters;
     }
 
-    public function getTransactionName(): string
+    public function getTransactionName(): ?string
     {
         return $this->transactionName;
     }

--- a/tests/Middleware/NewRelicTransactionNameMiddlewareTest.php
+++ b/tests/Middleware/NewRelicTransactionNameMiddlewareTest.php
@@ -40,13 +40,12 @@ class NewRelicTransactionNameMiddlewareTest extends TestCase
      */
     public function testProcessFailure()
     {
-        $path    = '/my-path1';
         $request = (new ServerRequest())
-            ->withUri(new Uri($path))
+            ->withUri(new Uri('/my-path1'))
             ->withAttribute(RouteResult::class, RouteResult::fromRouteFailure(null));
 
         $this->subject->process($request, $this->createMock(RequestHandlerInterface::class));
-        static::assertEquals($path, $this->newRelicAgent->getTransactionName());
+        static::assertNull($this->newRelicAgent->getTransactionName());
     }
 
     protected function setUp(): void


### PR DESCRIPTION
Currently, when a request reaching NewRelicMiddleware has no matched routed, we are using the request path as the transaction name.
This is not the default New Relic behavior. We should never use the request path as transaction name as request path could have parameters.
If we just don't name the transaction at all, New Relic will default the transaction name to the PHP script name (intended behavior).
This PR fixes this, so shouldn't be considered a breaking change.